### PR TITLE
Changed number-input to prevent any invalid inputs

### DIFF
--- a/src/components/number-input.js
+++ b/src/components/number-input.js
@@ -28,13 +28,17 @@ class NumberInput extends Input {
     }
 
     onChange(e) {
-        if(e.target.value !== '' && !this._isGoingToBeDecimal(e.target.value)) {
+        e.target.value = e.target.value.replace(',', '.');
+        if(!_.isNaN(Number(e.target.value))) {
+            if(this._isGoingToBeDecimal(e.target.value) || e.target.value === '') {
+                super.onChange(e);
+                return;
+            }
+
             const event = SyntheticEvent(e);
-            event.target.value = parseFloat(e.target.value);
+            event.target.value = Number(e.target.value);
             super.onChange(event);
-            return;
         }
-        super.onChange(e);
     }
 
     _isGoingToBeDecimal(value) {

--- a/src/utils/formatter.js
+++ b/src/utils/formatter.js
@@ -6,8 +6,8 @@ class formatter {
         this.locale = locale;
     }
 
-    _frenchReplace = value => value.replace('-', '').replace(',', '\u00A0').replace('.', ',');
-    _englishReplace = value => value.replace('-', '').replace(' ', ',').replace('\u00A0', ',');
+    _frenchReplace = value => _.trim(value.replace('-', '').replace(',', '\u00A0').replace('.', ','), '.,');
+    _englishReplace = value => _.trim(value.replace('-', '').replace(' ', ',').replace('\u00A0', ','), '.,');
     _isPositive = value => parseFloat((value + '').replace(',', '.')) >= 0;
 
     noFormat = value => value;


### PR DESCRIPTION
Small tweaks to the `number-input`component.

Fixed the use of `,` it wouldn't let me write floats
Fixed the case where I would be able to enter letters when input was empty, leading to `NaN`
Fixed trailing ',' or '.' in when formatted